### PR TITLE
Fix dracula + Use sets for `animateCode`

### DIFF
--- a/docsrc/nimconf2022.nim
+++ b/docsrc/nimconf2022.nim
@@ -639,7 +639,7 @@ slide:
     nbText: "## Using Templates"
   nimConfAutoSlide:
     nbText: "## Using Templates"
-    nbCodeDontRunAnimate([@[1..1, 3..3, 6..6]]):
+    nbCodeDontRunAnimate({1, 3, 6}):
       slide(slideOptions(autoAnimate=true)):
         nbText: "## Animate header"
       slide(slideOptions(autoAnimate=true)):

--- a/docsrc/tutorials/code_block.nim
+++ b/docsrc/tutorials/code_block.nim
@@ -50,14 +50,14 @@ Poof! The output is gone!
 One cool feature of Reveal.js is the animated code blocks.
 It allows you to create a code block like the ones we have created above, but highlight specific lines.
 This is done using the `animateCode` template by providing which lines to highlight and in which order.
-The lines can be specified either as a slice `x..y` or a single line number `x`.
+The lines can be specified either as a slice `x..y`, a single line number `x`, or a set of lines `{x, y}`.
 Note that the first line has line number 1 (and not 0).
 """
 
 
 codeAndSlides:
   slide:
-    animateCode(1, 2..3, 5, 3..4):
+    animateCode(1, 2..3, 5, {2, 4}):
       let x1 = 1
       let x2 = 2
       let x3 = 3
@@ -65,7 +65,7 @@ codeAndSlides:
       let x5 = 5
 
 nbText: hlMd"""
-As you can see, first line 1 is highlighted, then lines 2 through 3, then line 5 and lastly line 3 through 4. Neat!
+As you can see, first line 1 is highlighted, then lines 2 through 3, then line 5 and lastly line 2 through 4. Neat!
 Note that there exists no `animateCodeInBlock` currently, but you can always wrap your `animateCode` inside a `block:` to get the same effect.
 The animated code block is also useful if you have a very long code snippet that you want to show as it will auto-scroll for you:
 """

--- a/nimiSlides.nimble
+++ b/nimiSlides.nimble
@@ -14,7 +14,7 @@ requires "nimib >= 0.3.9"
 import os
 
 task docsDeps, "install dependencies required to build docs":
-    exec "nimble -y install ggplotnim@0.5.6 karax numericalnim nimibook"
+    exec "nimble -y install ggplotnim@0.5.6 karax numericalnim nimibook@#head"
 
 task buildDocs, "build all .nim files in docsrc/":
     for (kind, path) in walkDir("docsrc/"):
@@ -28,8 +28,8 @@ task buildDocs, "build all .nim files in docsrc/":
                 exec buildCommand
 
 task buildBook, "Builds the nimiBook docs":
-    selfExec(" r -d:release nbook.nim init")
-    selfExec(" r -d:release -f -d:nimibMaxProcesses=1 -d:nimibParallelBuild=false nbook.nim build")
+    selfExec(" r nbook.nim init")
+    selfExec(" r nbook.nim build")
 
 task docs, "Generate automatic docs":
     exec "nim doc --project --index:on --git.url:https://github.com/HugoGranstrom/nimiSlides --git.commit:main --outdir:docs/docs src/nimiSlides.nim"

--- a/nimiSlides.nimble
+++ b/nimiSlides.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.2"
+version       = "0.2.3"
 author        = "Hugo Granström"
 description   = "Reveal.js theme for nimib"
 license       = "MIT"

--- a/nimiSlides.nimble
+++ b/nimiSlides.nimble
@@ -17,15 +17,14 @@ task docsDeps, "install dependencies required to build docs":
     exec "nimble -y install ggplotnim@0.5.6 karax numericalnim nimibook@#head"
 
 task buildDocs, "build all .nim files in docsrc/":
-    for (kind, path) in walkDir("docsrc/"):
-        if path.endsWith(".nim"):
-            if "index" in path: continue 
-            echo "Building: " & path
-            let buildCommand = "nim r " & path
+    for path in ["showcase.nim", "nimconf2022.nim", "miscSlides.nim", "index_old.nim", "fragments.nim"]:
+        let path = "docsrc" / path
+        echo "Building: " & path
+        let buildCommand = "nim r " & path
+        exec buildCommand
+        if "showcase" in path:
+            let buildCommand = "nim r -d:themeWhite " & path
             exec buildCommand
-            if "showcase" in path:
-                let buildCommand = "nim r -d:themeWhite " & path
-                exec buildCommand
 
 task buildBook, "Builds the nimiBook docs":
     selfExec(" r nbook.nim init")

--- a/src/nimiSlides.nim
+++ b/src/nimiSlides.nim
@@ -420,6 +420,16 @@ template animateCode*(lines: string, body: untyped) =
       body
 
 template animateCode*(lines: varargs[set[range[0..65535]], toSet], body: untyped) =
+  ## Shows code and its output just like nbCode, but highlights different lines of the code in the order specified in `lines`.
+  ## lines: Specify which lines to highlight and in which order. The lines can be specified using either:
+  ## - An `int` (highlight single line)
+  ## - A slice `x..y` (highlight a range of consequative lines)
+  ## - A set {x, y..z} (highlight any combination of lines)
+  ## Ex: 
+  ## ```nim
+  ## animateCode(1, 2..3, {4, 6}): body
+  ## ```
+  ## This will first highlight line 1, then lines 2 and 3, and lastly line 4 and 6.
   newNbCodeBlock("animateCode", body):
     var linesString: string
     if lines.len > 0:

--- a/src/nimiSlides.nim
+++ b/src/nimiSlides.nim
@@ -159,6 +159,9 @@ template showSlideNumber*() =
 template disableVerticalCentering*() =
   nb.context["disableCentering"] = true
 
+proc addStyle*(doc: NbDoc, style: string) =
+  doc.context["nb_style"] = doc.context["nb_style"].vString & "\n" & style
+
 proc revealTheme*(doc: var NbDoc) =
   doc.partials["document"] = document
   doc.partials["head"] = head
@@ -190,6 +193,15 @@ proc revealTheme*(doc: var NbDoc) =
   doc.context["slidesTheme"] = "black"
   doc.context["nb_style"] = ""
 
+  doc.addStyle: """
+    .nimislides-li {
+      position: relative;
+    }
+
+    .nimislides-li::before {
+      position: absolute;
+    }
+  """
 
   try:
     let slidesConfig = loadTomlSection(doc.rawCfg, "nimislides", NimiSlidesConfig)
@@ -198,9 +210,6 @@ proc revealTheme*(doc: var NbDoc) =
       doc.useLocalReveal(slidesConfig.localReveal)
   except CatchableError:
     discard # if it doesn't exists, just let it be
-
-proc addStyle*(doc: NbDoc, style: string) =
-  doc.context["nb_style"] = doc.context["nb_style"].vString & "\n" & style
 
 var currentFragment*, currentSlideNumber*: int
 
@@ -378,7 +387,7 @@ template listItem*(animation: seq[FragmentAnimation], body: untyped) =
   for an in animation:
     classString &= $an & " "
   fadeInNext:
-    nbRawHtml: """<li class="fragment $1" data-fragment-index="$2" data-fragment-index-nimib="$2">""" % [classString, $currentFragment]
+    nbRawHtml: """<li class="fragment $1 nimislides-li" data-fragment-index="$2" data-fragment-index-nimib="$2">""" % [classString, $currentFragment]
     currentFragment += 1
     body
     nbRawHtml: "</li>"

--- a/src/nimiSlides.nim
+++ b/src/nimiSlides.nim
@@ -444,66 +444,25 @@ template animateCode*(lines: varargs[set[range[0..65535]], toSet], body: untyped
     captureStdout(nb.blk.output):
       body
 
-#[ template animateCode*(lines: varargs[seq[HSlice[int, int]]], body: untyped) =
-  ## Shows code and its output just like nbCode, but highlights different lines of the code in the order specified in `lines`.
-  ## lines: Specify which lines to highlight and in which order. (Must be specified as a seq[HSlice])
-  ## Ex: 
-  ## ```nim
-  ## animateCode(@[1..1], @[3..4, 6..6]): body
-  ## ```
-  ## This will first highlight line 1, then lines 3, 4 and 6.
-  newNbCodeBlock("animateCode", body):
-    var linesString: string
-    if lines.len > 0:
-      linesString &= "|"
-    for lineBundle in lines:
-      for line in lineBundle:
-        linesString &= $line.a & "-" & $line.b & ","
-      linesString &= "|"
-    if lines.len > 0:
-      linesString = linesString[0 .. ^3]
-    nb.blk.context["highlightLines"] = linesString
-    captureStdout(nb.blk.output):
-      body
-
-template animateCode*(lines: varargs[HSlice[int, int], toHSlice], body: untyped) =
-  ## Shows code and its output just like nbCode, but highlights different lines of the code in the order specified in `lines`.
-  ## lines: Specify which lines to highlight and in which order. (Must be specified as a HSlice)
-  ## Ex: 
-  ## ```nim
-  ## animateCode(1..1, 2..3, 5..5, 4..4): body
-  ## ```
-  ## This will first highlight line 1, then lines 2 and 3, then line 5 and last line 4.
-  var s: seq[seq[HSlice[int, int]]]
-  for line in lines:
-    s.add @[line]
-  animateCode(s):
-    body ]#
-
 template newAnimateCodeBlock*(cmd: untyped, impl: untyped) =
-  template `cmd`*(lines: varargs[seq[HSlice[int, int]]], body: untyped) =
-    newNbCodeBlock(cmd.astToStr, body):
+  const cmdStr = astToStr(cmd)
+
+  template `cmd`*(lines: varargs[set[range[0..65535]], toSet], body: untyped) =
+    newNbCodeBlock(cmdStr, body):
       var linesString: string
       if lines.len > 0:
         linesString &= "|"
       for lineBundle in lines:
         for line in lineBundle:
-          linesString &= $line.a & "-" & $line.b & ","
+          linesString &= $line & ","
         linesString &= "|"
       if lines.len > 0:
         linesString = linesString[0 .. ^3]
       nb.blk.context["highlightLines"] = linesString
     impl(body)
 
-  template `cmd`*(lines: varargs[HSlice[int, int], toHSlice], body: untyped) =
-    var s: seq[seq[HSlice[int, int]]]
-    for line in lines:
-      s.add @[line]
-    `cmd`(s):
-      body
-
-  nb.partials[cmd.astToStr] = nb.partials["animateCode"]
-  nb.renderPlans[cmd.astToStr] = nb.renderPlans["animateCode"]
+  nb.partials[cmdStr] = nb.partials["animateCode"]
+  nb.renderPlans[cmdStr] = nb.renderPlans["animateCode"]
 
 template typewriter*(textMessage: string, typeSpeed = 50, alignment = "center") =
   let localText = textMessage


### PR DESCRIPTION
Fixes #30 by adding a piece of CSS to fix the styling.
Fixes #31 by rewriting `animateCode` to use sets as the base type. This means that we only need one template instead of 2 as before. This is nice because we can now mix sets and ranges like this: `{1, 3..5}` (highlight line 1, 3, 4, 5 at the same time). And as you can see, now we can highlight lines that aren't next to each other easily (It was possible before, but required using seqs which wasn't ergonomic).