### PR TITLE
add converter from new default set type

### DIFF
--- a/.github/workflows/valid.yml
+++ b/.github/workflows/valid.yml
@@ -1,4 +1,4 @@
-name: Generate nimiSlides docs
+name: Tests
 
 on:
   pull_request:

--- a/.github/workflows/valid.yml
+++ b/.github/workflows/valid.yml
@@ -6,13 +6,21 @@ on:
       - main
 
 jobs:
-  gen:
-    name: Validate PR
-    runs-on: ubuntu-latest  
-
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nim:
+          - 'binary:1.6.x'
+          - 'binary:stable'
+          - 'devel'
+      fail-fast: false
+    name: Nim ${{ matrix.nim }}
     steps:
       - uses: actions/checkout@v2
       - uses: iffy/install-nim@v4
+        with:
+          version: ${{ matrix.version }}
       - name: Install deps
         run: |
           nimble install -y

--- a/.github/workflows/valid.yml
+++ b/.github/workflows/valid.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: iffy/install-nim@v4
         with:
-          version: ${{ matrix.version }}
+          version: ${{ matrix.nim }}
       - name: Install deps
         run: |
           nimble install -y

--- a/.github/workflows/valid.yml
+++ b/.github/workflows/valid.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         nim:
-          - 'binary:1.6.x'
+          - '1.6.x'
           - 'binary:stable'
           - 'devel'
       fail-fast: false

--- a/.github/workflows/valid.yml
+++ b/.github/workflows/valid.yml
@@ -12,15 +12,16 @@ jobs:
       matrix:
         nim:
           - '1.6.x'
-          - 'binary:stable'
+          - 'stable'
           - 'devel'
       fail-fast: false
     name: Nim ${{ matrix.nim }}
     steps:
       - uses: actions/checkout@v2
-      - uses: iffy/install-nim@v4
+      - uses: jiro4989/setup-nim-action@v1
         with:
           version: ${{ matrix.nim }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install deps
         run: |
           nimble install -y

--- a/nimiSlides.nimble
+++ b/nimiSlides.nimble
@@ -14,7 +14,7 @@ requires "nimib >= 0.3.9"
 import os
 
 task docsDeps, "install dependencies required to build docs":
-    exec "nimble -y install ggplotnim@0.5.6 karax numericalnim nimibook"
+    exec "nimble -y install ggplotnim@0.5.6 karax numericalnim nimibook@#head"
 
 task buildDocs, "build all .nim files in docsrc/":
     for path in ["showcase.nim", "nimconf2022.nim", "miscSlides.nim", "index_old.nim", "fragments.nim"]:

--- a/nimiSlides.nimble
+++ b/nimiSlides.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.3"
+version       = "0.2.4"
 author        = "Hugo Granström"
 description   = "Reveal.js theme for nimib"
 license       = "MIT"
@@ -14,7 +14,7 @@ requires "nimib >= 0.3.9"
 import os
 
 task docsDeps, "install dependencies required to build docs":
-    exec "nimble -y install ggplotnim@0.5.6 karax numericalnim nimibook@#head"
+    exec "nimble -y install ggplotnim@0.5.6 karax numericalnim nimibook"
 
 task buildDocs, "build all .nim files in docsrc/":
     for path in ["showcase.nim", "nimconf2022.nim", "miscSlides.nim", "index_old.nim", "fragments.nim"]:

--- a/src/nimiSlides.nim
+++ b/src/nimiSlides.nim
@@ -411,6 +411,9 @@ proc toSet*(x: Slice[int]): set[range[0..65535]] =
 proc toSet*(x: seq[Slice[int]]): set[range[0..65535]] =
   for s in x:
     result.incl s.toSet()
+proc toSet*(x: set[range[0..255]]): set[range[0..65535]] =
+  for y in x:
+    result.incl y
 
 
 template animateCode*(lines: string, body: untyped) =


### PR DESCRIPTION
In Nim 2.0 the default set type (`{1, 2, 3}`) changed from `set[range[0..65535]]` to `set[range[0..255]]`. This PR adds a converter so that both types are allowed. 

Also run tests on 1.6.x, stable and devel.