### PR TITLE
Update Reveal.js to 5.0.2

### DIFF
--- a/docsrc/tutorials/pdf_export.nim
+++ b/docsrc/tutorials/pdf_export.nim
@@ -6,7 +6,7 @@ nbText: hlMd"""
 Reveal.js has support for exporting a slideshow to PDF using the print function in your browser.
 See [their documentation](https://revealjs.com/pdf-export/) for instructions.
 Here's a quick list of important notes:
-- Change the url from, for example `http://localhost:8000/slides.html` to `http://localhost:8000/slides.html?print-pdf`. This will show a printer-friendly version of your slides.
+- Change the url from, for example `http://localhost:8000/slides.html` to `http://localhost:8000/slides.html?view=print`. This will show a printer-friendly version of your slides.
 - It only works reliably on Chromium based browsers.
 """
 

--- a/docsrc/utils/embeddedReveal.nim
+++ b/docsrc/utils/embeddedReveal.nim
@@ -3,16 +3,16 @@ import std / [strutils]
 
 template initEmbeddedSlides*(slidesTheme: SlidesTheme = Black) =
   nbRawHtml: hlHtml"""
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/reveal.min.css" integrity="sha512-USp+nLNMZ1hR0Ll/LpYDxIq47Ypcm3KfjIleOnyFrB1N5KfHLXjfPQD1wQlhv7kVHRRgPvNVtendDS72LyHviA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/theme/$1.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/$2/reveal.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/$2/theme/$1.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/highlight/monokai.min.css" integrity="sha512-z8wQkuDRFwCBfoj7KOiu1MECaRVoXx6rZQWL21x0BsVVH7JkqCp1Otf39qve6CrCycOOL5o9vgfII5Smds23rg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/$2/plugin/highlight/monokai.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/reveal.js" integrity="sha512-9dFFU5pcR8K4bvw4ng6mLMW5IjslYbA57amHEMtHn3TT9RkKivsDabKffqjUUJ4pCaojAyH05T1OESld199Gcw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/highlight/highlight.min.js" integrity="sha512-RCedMo/DOyawQOh4zYtqEHTZAfgrrVQctN3LVCX5kELGsN52TOdwZ8inRY0l9Mo4vtyDFn6oOAgRUilWXgb+wA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/notes/notes.min.js" integrity="sha512-MZ7Ehjbh2soaeCZJGaw6vBNAa7+eunl0SUmRPNESchLlboH73lHLEeUa6pZJ2Pcui4NcpDFatr6M+VlcmaH1QA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/math/math.min.js" integrity="sha512-skPZpuRwuUAnF9iEEFBXc4zJaucKcHUDgY1wDBTv0ILy82C2gn8MJsbcinzj2u8r/iZjD/78HRgw2/n//poOhQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-""" % [($slidesTheme).toLower()]
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/$2/reveal.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/$2/plugin/highlight/highlight.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/$2/plugin/notes/notes.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/$2/plugin/math/math.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+""" % [($slidesTheme).toLower(), reveal_version]
 
   nbRawHtml: """
 <style>

--- a/src/nimiSlides.nim
+++ b/src/nimiSlides.nim
@@ -51,6 +51,8 @@ proc slideOptions*(autoAnimate = false, iframeInteractive = true, colorBackgroun
     gradientBackground: gradientBackground,
   )
 
+const reveal_version* = "5.0.2"
+
 const document = """
 <!DOCTYPE html>
 <html>
@@ -111,18 +113,18 @@ const main = """
 """
 
 const revealCSS = """
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/reveal.min.css" integrity="sha512-USp+nLNMZ1hR0Ll/LpYDxIq47Ypcm3KfjIleOnyFrB1N5KfHLXjfPQD1wQlhv7kVHRRgPvNVtendDS72LyHviA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/theme/{{{slidesTheme}}}.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{{reveal_version}}}/reveal.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{{reveal_version}}}/theme/{{{slidesTheme}}}.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/highlight/monokai.min.css" integrity="sha512-z8wQkuDRFwCBfoj7KOiu1MECaRVoXx6rZQWL21x0BsVVH7JkqCp1Otf39qve6CrCycOOL5o9vgfII5Smds23rg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{{reveal_version}}}/plugin/highlight/monokai.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 """
 
 const revealJS = """
-<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/reveal.js" integrity="sha512-9dFFU5pcR8K4bvw4ng6mLMW5IjslYbA57amHEMtHn3TT9RkKivsDabKffqjUUJ4pCaojAyH05T1OESld199Gcw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/highlight/highlight.min.js" integrity="sha512-RCedMo/DOyawQOh4zYtqEHTZAfgrrVQctN3LVCX5kELGsN52TOdwZ8inRY0l9Mo4vtyDFn6oOAgRUilWXgb+wA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/notes/notes.min.js" integrity="sha512-MZ7Ehjbh2soaeCZJGaw6vBNAa7+eunl0SUmRPNESchLlboH73lHLEeUa6pZJ2Pcui4NcpDFatr6M+VlcmaH1QA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{{reveal_version}}}/reveal.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{{reveal_version}}}/plugin/highlight/highlight.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{{reveal_version}}}/plugin/notes/notes.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 {{#latex}}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/plugin/math/math.min.js" integrity="sha512-skPZpuRwuUAnF9iEEFBXc4zJaucKcHUDgY1wDBTv0ILy82C2gn8MJsbcinzj2u8r/iZjD/78HRgw2/n//poOhQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{{reveal_version}}}/plugin/math/math.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 {{/latex}}
 """
 
@@ -192,16 +194,7 @@ proc revealTheme*(doc: var NbDoc) =
 
   doc.context["slidesTheme"] = "black"
   doc.context["nb_style"] = ""
-
-  doc.addStyle: """
-    .nimislides-li {
-      position: relative;
-    }
-
-    .nimislides-li::before {
-      position: absolute;
-    }
-  """
+  doc.context["reveal_version"] = reveal_version
 
   try:
     let slidesConfig = loadTomlSection(doc.rawCfg, "nimislides", NimiSlidesConfig)

--- a/src/nimiSlides.nim
+++ b/src/nimiSlides.nim
@@ -107,6 +107,9 @@ const main = """
     {{#disableCentering}}
     center: false,
     {{/disableCentering}}
+    {{#useScrollView}}
+    view: 'scroll',
+    {{/useScrollView}}
   });
 {{> customJS}}
 </script>
@@ -160,6 +163,9 @@ template showSlideNumber*() =
 
 template disableVerticalCentering*() =
   nb.context["disableCentering"] = true
+
+template useScrollView*() =
+  nb.context["useScrollView"] = true
 
 proc addStyle*(doc: NbDoc, style: string) =
   doc.context["nb_style"] = doc.context["nb_style"].vString & "\n" & style


### PR DESCRIPTION
Closes #37 

The version is now set in the context (`nb.context["reveal_version"]`) so now it can be easily modified.

Scroll view is activated using `useScrollView()`.